### PR TITLE
Fixed haml error in admin menu hide button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,14 @@ ruby '2.3.3'
 
 gem 'rails', '~> 4.2.6'
 gem 'rails_12factor'
+
 # Use Postgresql as the database for Active Record
-gem 'pg'
 gem 'haml'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'mini_magick', '~> 3.6.0'
 gem 'nokogiri'
+gem 'pg'
 gem 'whenever'
 
 gem 'browser'
@@ -72,7 +73,9 @@ group :development, :test do
 end
 
 group :test do
-  gem "codeclimate-test-reporter", "~> 1.0.0"
+  gem 'capybara'
+  gem 'capybara-screenshot'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,16 @@ GEM
     browser (2.5.0)
     builder (3.2.3)
     byebug (9.1.0)
+    capybara (2.15.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-screenshot (1.0.17)
+      capybara (>= 1.0, < 3)
+      launchy
     chronic (0.10.2)
     ckeditor_rails (4.6.2)
       railties (>= 3.0)
@@ -128,6 +138,7 @@ GEM
     mimemagic (0.3.2)
     mini_magick (3.6.0)
       subexec (~> 0.2.1)
+    mini_mime (0.1.4)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
     modernizr-rails (2.7.1)
@@ -277,6 +288,8 @@ GEM
     whenever (0.9.7)
       chronic (>= 0.6.3)
     will_paginate (3.1.6)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -284,6 +297,8 @@ PLATFORMS
 DEPENDENCIES
   brakeman
   browser
+  capybara
+  capybara-screenshot
   ckeditor_rails
   codeclimate-test-reporter (~> 1.0.0)
   coffee-rails
@@ -323,9 +338,8 @@ DEPENDENCIES
   whenever
   will_paginate
 
-
 RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -31,8 +31,8 @@
       #admin-dashboard-sidebar.admin-dashboard-sidebar.position-left.off-canvas.off-canvas-absolute.reveal-for-medium.data-off-canvas
         .admin-dashboard-sidebar-title-area
           .admin-dashboard-open-sidebar
-            %button.admin-dashboard-open-sidebar-button
-            .show-for-medium{ 'aria-label': "open menu", type: "button" }#open-sidebar
+            %button#open-sidebar.admin-dashboard-open-sidebar-button.show-for-medium{ 'aria-label': "open menu",
+                                                                                      type: "button" }
               %span{ 'aria-hidden': "true" }
                 %a{ href: "#" }
                   %i.large.fa.fa-angle-double-right

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -31,7 +31,7 @@
       #admin-dashboard-sidebar.admin-dashboard-sidebar.position-left.off-canvas.off-canvas-absolute.reveal-for-medium.data-off-canvas
         .admin-dashboard-sidebar-title-area
           .admin-dashboard-open-sidebar
-            %button#open-sidebar.admin-dashboard-open-sidebar-button.show-for-medium{ 'aria-label': "open menu",
+            %button.admin-dashboard-open-sidebar-button.show-for-medium#open-sidebar{ 'aria-label': "open menu",
                                                                                       type: "button" }
               %span{ 'aria-hidden': "true" }
                 %a{ href: "#" }

--- a/spec/features/admin_login_spec.rb
+++ b/spec/features/admin_login_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin login', type: :feature do
+  let(:user) { FactoryGirl.create :user }
+
+  context 'log in as admin user' do
+    background { login_as(user) }
+
+    scenario 'views admin path' do
+      visit admin_path
+      expect(page).to have_text('New Page')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+require 'capybara/rspec'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
@@ -26,6 +27,8 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include Warden::Test::Helpers
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -49,5 +52,5 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.include SpecHelpers::AuthHelper, type: :controller
+  # config.include SpecHelpers::AuthHelper, type: :controller
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,4 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
-
-  # config.include SpecHelpers::AuthHelper, type: :controller
 end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,8 +1,0 @@
-module SpecHelpers
-  module AuthHelper
-    def basic_auth(user, password)
-      credentials = ActionController::HttpAuthentication::Basic.encode_credentials user, password
-      request.env['HTTP_AUTHORIZATION'] = credentials
-    end
-  end
-end


### PR DESCRIPTION
Reverted to the old html, and used attribute wrapping in haml - fixes haml parse error.