### PR TITLE
Bug/vocab sheet support 148

### DIFF
--- a/app/assets/javascripts/vocab_bar.js
+++ b/app/assets/javascripts/vocab_bar.js
@@ -2,9 +2,10 @@ $(document).ready(function() {
 
   function hideVocabSheetOnMobile() {
     var bar = $('.vocab_sheet_bar');
+    bar.show();
     var windowWidth = $(window).width();
     if((windowWidth < 640) || (bar.length && bar.find('.vocab_sheet_bar_item').length === 0)) {
-      bar.hide();
+      // bar.hide();
       $('.not_sticky_footer').removeClass('vocab_sheet_background');
     } else if ((windowWidth > 639) && ($('.vocab_sheet_bar').length)) {
       bar.show();
@@ -14,9 +15,9 @@ $(document).ready(function() {
 
   function changeVocabLocation() {
     if($('.search-result-banner').length > 0 && $('.flash').length > 0) {
-      $('.vocab_sheet_bar').css("top", "350px")
+      $('.vocab_sheet_bar').css("top", "380px")
     } else if ($('.search-result-banner').length > 0 && $('.flash').length < 1) {
-      $('.vocab_sheet_bar').css("top", "320px")
+      $('.vocab_sheet_bar').css("top", "340px")
     } else {
       return
     }

--- a/app/assets/javascripts/vocab_bar.js
+++ b/app/assets/javascripts/vocab_bar.js
@@ -1,12 +1,12 @@
 $(document).ready(function() {
 
   function hideVocabSheetOnMobile() {
-    var bar = $('.js_vocab_sheet_bar');
+    var bar = $('.vocab_sheet');
     var windowWidth = $(window).width();
-    if((windowWidth < 640) || (bar.length && bar.find('.vocab_sheet_bar_item').length === 0)) {
+    if(windowWidth < 640 || (bar.length && bar.find('.vocab_sheet_bar_item').length === 0)) {
       bar.hide();
       $('.not_sticky_footer').removeClass('vocab_sheet_background');
-    } else if ((windowWidth > 639) && ($('.js_vocab_sheet_bar').length)) {
+    } else if (windowWidth > 639 && $('.vocab_sheet').length) {
       bar.show();
       $('.not_sticky_footer').addClass('vocab_sheet_background');
     }
@@ -14,9 +14,9 @@ $(document).ready(function() {
 
   function changeVocabLocation() {
     if($('.search-result-banner').length > 0 && $('.flash').length > 0) {
-      $('.js_vocab_sheet_bar').css("top", "380px")
+      $('.vocab_sheet').css("top", "380px")
     } else if ($('.search-result-banner').length > 0 && $('.flash').length < 1) {
-      $('.js_vocab_sheet_bar').css("top", "340px")
+      $('.vocab_sheet').css("top", "340px")
     } else {
       return
     }

--- a/app/assets/javascripts/vocab_bar.js
+++ b/app/assets/javascripts/vocab_bar.js
@@ -1,13 +1,12 @@
 $(document).ready(function() {
 
   function hideVocabSheetOnMobile() {
-    var bar = $('.vocab_sheet_bar');
-    bar.show();
+    var bar = $('.js_vocab_sheet_bar');
     var windowWidth = $(window).width();
     if((windowWidth < 640) || (bar.length && bar.find('.vocab_sheet_bar_item').length === 0)) {
-      // bar.hide();
+      bar.hide();
       $('.not_sticky_footer').removeClass('vocab_sheet_background');
-    } else if ((windowWidth > 639) && ($('.vocab_sheet_bar').length)) {
+    } else if ((windowWidth > 639) && ($('.js_vocab_sheet_bar').length)) {
       bar.show();
       $('.not_sticky_footer').addClass('vocab_sheet_background');
     }
@@ -15,9 +14,9 @@ $(document).ready(function() {
 
   function changeVocabLocation() {
     if($('.search-result-banner').length > 0 && $('.flash').length > 0) {
-      $('.vocab_sheet_bar').css("top", "380px")
+      $('.js_vocab_sheet_bar').css("top", "380px")
     } else if ($('.search-result-banner').length > 0 && $('.flash').length < 1) {
-      $('.vocab_sheet_bar').css("top", "340px")
+      $('.js_vocab_sheet_bar').css("top", "340px")
     } else {
       return
     }

--- a/app/assets/stylesheets/_vocab_sheet.scss
+++ b/app/assets/stylesheets/_vocab_sheet.scss
@@ -46,7 +46,7 @@
 }
 
 /* bar specific */
-.vocab_sheet_bar {
+.js_vocab_sheet_bar {
   width: 120px;
   position: absolute;
   right: 0;
@@ -162,7 +162,7 @@
   width: 100%;
 }
 
-.vocab_sheet_bar .flash {
+.js_vocab_sheet_bar .flash {
   @include border-radius-small;
   margin: 20px auto;
   background: $primary-blue;

--- a/app/assets/stylesheets/_vocab_sheet.scss
+++ b/app/assets/stylesheets/_vocab_sheet.scss
@@ -16,6 +16,7 @@
 .vocab_sheet {
   position: relative;
   text-align: center;
+  display: none;
 }
 
 .vocab_sheet ul {
@@ -46,7 +47,7 @@
 }
 
 /* bar specific */
-.js_vocab_sheet_bar {
+.vocab_sheet_bar {
   width: 120px;
   position: absolute;
   right: 0;
@@ -162,7 +163,7 @@
   width: 100%;
 }
 
-.js_vocab_sheet_bar .flash {
+.vocab_sheet_bar .flash {
   @include border-radius-small;
   margin: 20px auto;
   background: $primary-blue;

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -24,7 +24,7 @@ a.main_gloss:after {font-size:10px;line-height:10px;}
 
 /* hiding useless things */
   .nav,
-  .vocab_sheet_bar,
+  .js_vocab_sheet_bar,
   .empty_vocab_sheet,
   .button,
   .logo,

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -24,7 +24,7 @@ a.main_gloss:after {font-size:10px;line-height:10px;}
 
 /* hiding useless things */
   .nav,
-  .js_vocab_sheet_bar,
+  .vocab_sheet_bar,
   .empty_vocab_sheet,
   .button,
   .logo,

--- a/app/models/vocab_sheet.rb
+++ b/app/models/vocab_sheet.rb
@@ -2,9 +2,8 @@
 # A "sheet" of items (signs) saved by a user
 class VocabSheet < ActiveRecord::Base
   has_many :items
-  validates :name, presence: true
 
-  def includes_sign?(sign_id:)
+  def includes_sign?(sign_id)
     items.any? { |i| i.sign_id == sign_id }
   end
 end

--- a/app/views/shared/_vocab_sheet.html.haml
+++ b/app/views/shared/_vocab_sheet.html.haml
@@ -1,4 +1,4 @@
-.vocab_sheet.vocab_sheet_bar{ style:  (vocab_sheet? ? '' : 'display:none') }
+.vocab_sheet.js_vocab_sheet_bar{ style:  (vocab_sheet? ? '' : 'display:none') }
   %h3.title= t('vocab_sheet.title')
   .vocab_sheet_controls.vocab_sheet_bar_controls.clearfix
     = link_button 'vocab_sheet.link_to', vocab_sheet_url

--- a/app/views/shared/_vocab_sheet.html.haml
+++ b/app/views/shared/_vocab_sheet.html.haml
@@ -1,4 +1,4 @@
-.vocab_sheet.js_vocab_sheet_bar{ style:  (vocab_sheet? ? '' : 'display:none') }
+.vocab_sheet.vocab_sheet_bar
   %h3.title= t('vocab_sheet.title')
   .vocab_sheet_controls.vocab_sheet_bar_controls.clearfix
     = link_button 'vocab_sheet.link_to', vocab_sheet_url

--- a/app/views/signs/search.html.haml
+++ b/app/views/signs/search.html.haml
@@ -1,7 +1,8 @@
 .search-result-banner.small-12.text-center
-  = @results_total
-  = t('search.results.for')
-  &ldquo;#{display_search_term}&rdquo;
+  %h2
+    = @results_total
+    = t('search.results.for')
+    &ldquo;#{display_search_term}&rdquo;
 .search_results_container.text-center.small-12.small-centered.medium-8.large-9
   .row#search-container{ data: { "equalizer": true } }
     - @signs.each do |sign|

--- a/spec/controllers/vocab_sheets_controller_spec.rb
+++ b/spec/controllers/vocab_sheets_controller_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe VocabSheetsController, type: :controller do
   let(:valid_attributes) do
     { vocab_sheet: { name: new_name } }
   end
-  let(:invalid_attributes) do
-    { vocab_sheet: { name: '' } }
+
   end
 
   describe '#show' do
@@ -51,13 +50,6 @@ RSpec.describe VocabSheetsController, type: :controller do
       it 'displays a success flash message' do
         patch :update, valid_attributes, session
         expect(flash[:notice]).to eq I18n.t('vocab_sheet.sheet.update_success')
-      end
-    end
-
-    context 'unsuccessful update' do
-      it 'displays an error flash message' do
-        patch :update, invalid_attributes, session
-        expect(flash[:error]).to eq I18n.t('vocab_sheet.sheet.update_failure')
       end
     end
   end

--- a/spec/controllers/vocab_sheets_controller_spec.rb
+++ b/spec/controllers/vocab_sheets_controller_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe VocabSheetsController, type: :controller do
     { vocab_sheet: { name: new_name } }
   end
 
-  end
-
   describe '#show' do
     before { get :show }
     it { expect(response).to have_http_status(:ok) }


### PR DESCRIPTION
Deleted validation and test that appear to have been added to meet test coverage expectation. This wasn't user tested, and that old commit broke the vocab sheets on prod. Both now work, overriding Travis' rule and failure due to 0.2% drop in test coverage with this commit.